### PR TITLE
Fixed deprecated include path

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -3,7 +3,7 @@
 #include "Task.hpp"
 #include <velodyne_lidar/pointcloudConvertHelper.hpp>
 #include <envire/maps/MLSGrid.hpp>
-#include <orocos/envire/Orocos.hpp>
+#include <envire/Orocos.hpp>
 
 
 using namespace local_mapper;


### PR DESCRIPTION
It seems that the include path to Orocos.hpp in envire has changed from
'orocos/envire/Orocos.hpp' to just 'envire/Orocos.hpp'.
With this change the task compiles again.

Signed-off-by: Moritz Schilling <moritz.schilling@dfki.de>